### PR TITLE
Update QUnit paths to look for npm-installed files.

### DIFF
--- a/shared/tests/qunit/_test.html
+++ b/shared/tests/qunit/_test.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>QUnit Example</title>
-  <link rel="stylesheet" href="../../bower_components/qunit/qunit/qunit.css">
+  <link rel="stylesheet" href="../../node_modules/qunitjs/qunit/qunit.css">
 </head>
 <body>
   <div id="qunit"></div>
   <div id="qunit-fixture"></div>
-  <script src="../../bower_components/qunit/qunit/qunit.js"></script>
+  <script src="../../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="tests/<%= fileSlug %>.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This addresses failing QUnit tests in #14 by switching paths from the bower files to those actually installed via npm.
