### PR TITLE
Edit Gruntfiles to watch .scss in sass subfolders, set sass precision

### DIFF
--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function( grunt ) {
 				'Gruntfile.js',
 				'assets/js/src/**/*.js',
 				'assets/js/test/**/*.js'
-			]		
+			]
 		},
 		uglify: {
 			all: {
@@ -46,6 +46,9 @@ module.exports = function( grunt ) {
 		<% if ( opts.sass ) { %>
 		sass:   {
 			all: {
+				options: {
+					precision: 2
+				},
 				files: {
 					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
 				}
@@ -76,10 +79,10 @@ module.exports = function( grunt ) {
 			},
 			minify: {
 				expand: true,
-				
-				cwd: 'assets/css/',				
+
+				cwd: 'assets/css/',
 				src: ['<%= fileSlug %>.css'],
-				
+
 				dest: 'assets/css/',
 				ext: '.min.css'
 			}
@@ -92,7 +95,7 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/*.scss'],
+				files: ['assets/css/sass/**/*.scss'],
 				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
 				files: ['assets/css/src/*.css'],
 				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
@@ -138,7 +141,7 @@ module.exports = function( grunt ) {
 					'!phpunit.xml.dist'
 				],
 				dest: 'release/<%%= pkg.version %>/'
-			}		
+			}
 		},
 		compress: {
 			main: {
@@ -150,7 +153,7 @@ module.exports = function( grunt ) {
 				cwd: 'release/<%%= pkg.version %>/',
 				src: ['**/*'],
 				dest: '<%= opts.funcPrefix %>/'
-			}		
+			}
 		},
 		phpunit: {
 			classes: {
@@ -166,10 +169,10 @@ module.exports = function( grunt ) {
 			all: ['tests/qunit/**/*.html']
 		}
 	} );
-	
+
 	// Load tasks
 	require('load-grunt-tasks')(grunt);
-	
+
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin' ] );
@@ -178,7 +181,7 @@ module.exports = function( grunt ) {
 	<% } else { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin' ] );
 	<% } %>
-	
+
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 
 	grunt.registerTask( 'test', ['phpunit', 'qunit'] );

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function( grunt ) {
 				'Gruntfile.js',
 				'assets/js/src/**/*.js',
 				'assets/js/test/**/*.js'
-			]		
+			]
 		},
 		uglify: {
 			all: {
@@ -45,6 +45,9 @@ module.exports = function( grunt ) {
 		},
 		<% if ( opts.sass ) { %>
 		sass:   {
+			options: {
+				precision: 2
+			},
 			all: {
 				files: {
 					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
@@ -76,10 +79,10 @@ module.exports = function( grunt ) {
 			},
 			minify: {
 				expand: true,
-				
-				cwd: 'assets/css/',				
+
+				cwd: 'assets/css/',
 				src: ['<%= fileSlug %>.css'],
-				
+
 				dest: 'assets/css/',
 				ext: '.min.css'
 			}
@@ -92,7 +95,7 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/*.scss'],
+				files: ['assets/css/sass/**/*.scss'],
 				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
 				files: ['assets/css/src/*.css'],
 				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
@@ -138,7 +141,7 @@ module.exports = function( grunt ) {
 					'!phpunit.xml.dist'
 				],
 				dest: 'release/<%%= pkg.version %>/'
-			}		
+			}
 		},
 		compress: {
 			main: {
@@ -150,7 +153,7 @@ module.exports = function( grunt ) {
 				cwd: 'release/<%%= pkg.version %>/',
 				src: ['**/*'],
 				dest: '<%= opts.funcPrefix %>/'
-			}		
+			}
 		},
 		wp_readme_to_markdown: {
 			readme: {
@@ -173,10 +176,10 @@ module.exports = function( grunt ) {
 			all: ['tests/qunit/**/*.html']
 		}
 	} );
-	
+
 	// Load tasks
 	require('load-grunt-tasks')(grunt);
-	
+
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin', 'wp_readme_to_markdown' ] );
@@ -185,7 +188,7 @@ module.exports = function( grunt ) {
 	<% } else { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin', 'wp_readme_to_markdown' ] );
 	<% } %>
-	
+
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 
 	grunt.registerTask( 'test', ['phpunit', 'qunit'] );

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -24,7 +24,7 @@ module.exports = function( grunt ) {
 				'Gruntfile.js',
 				'assets/js/src/**/*.js',
 				'assets/js/test/**/*.js'
-			]		
+			]
 		},
 		uglify: {
 			all: {
@@ -46,6 +46,9 @@ module.exports = function( grunt ) {
 		<% if ( opts.sass ) { %>
 		sass:   {
 			all: {
+				options: {
+					precision: 2
+				},
 				files: {
 					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
 				}
@@ -75,10 +78,10 @@ module.exports = function( grunt ) {
 			},
 			minify: {
 				expand: true,
-				
+
 				cwd: 'assets/css/',
 				src: ['<%= fileSlug %>.css'],
-				
+
 				dest: 'assets/css/',
 				ext: '.min.css'
 			}
@@ -91,7 +94,7 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/*.scss'],
+				files: ['assets/css/sass/**/*.scss'],
 				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
 				files: ['assets/css/src/*.css'],
 				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
@@ -137,7 +140,7 @@ module.exports = function( grunt ) {
 					'!phpunit.xml.dist'
 				],
 				dest: 'release/<%%= pkg.version %>/'
-			}		
+			}
 		},
 		compress: {
 			main: {
@@ -149,7 +152,7 @@ module.exports = function( grunt ) {
 				cwd: 'release/<%%= pkg.version %>/',
 				src: ['**/*'],
 				dest: '<%= opts.funcPrefix %>/'
-			}		
+			}
 		},
 		phpunit: {
 			classes: {
@@ -165,10 +168,10 @@ module.exports = function( grunt ) {
 			all: ['tests/qunit/**/*.html']
 		}
 	} );
-	
+
 	// Load tasks
 	require('load-grunt-tasks')(grunt);
-	
+
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin' ] );
@@ -177,7 +180,7 @@ module.exports = function( grunt ) {
 	<% } else { %>
 	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin' ] );
 	<% } %>
-	
+
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 
 	grunt.registerTask( 'test', ['phpunit', 'qunit'] );


### PR DESCRIPTION
When running grunt watch, it's currently not updating if we have .scss partials in subfolders.

Also set precision to 2, since most browsers won't take into account more digits.
