### PR TITLE
Update to grunt-sass and postcss, create subtasks for css and js

### DIFF
--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function( grunt ) {
 		sass:   {
 			all: {
 				options: {
-					precision: 2
+					precision: 2,
+					sourceMap: true
 				},
 				files: {
 					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
@@ -177,12 +178,16 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin' ] );
+	grunt.registerTrask( 'css', ['sass', 'postcss', 'cssmin'] );
 	<% } else if ( opts.autoprefixer ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'autoprefixer', 'cssmin'] );
+	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin' ] );
+	grunt.registerTask( 'css', ['cssmin'] );
 	<% } %>
+
+	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
+
+	grunt.registerTask( 'default', ['css', 'js'] );
 
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -178,7 +178,7 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTrask( 'css', ['sass', 'postcss', 'cssmin'] );
+	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
 	<% } else if ( opts.autoprefixer ) { %>
 	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -56,10 +56,12 @@ module.exports = function( grunt ) {
 		},
 		<% } %>
 		<% if ( opts.autoprefixer ) { %>
-		autoprefixer: {
+		postcss: {
 			dist: {
 				options: {
-					browsers: [ 'last 1 version', '> 1%', 'ie 8' ]
+					processors: [
+						require('autoprefixer-core')({browsers: 'last 2 versions'})
+					]
 				},
 				files: { <% if ( opts.sass ) { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/<%= fileSlug %>.css' ]<% } else { %>

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -17,8 +17,9 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.8.0",<% if ( opts.sass ) { %>
-    "grunt-contrib-sass": "^0.9.2",<% } if ( opts.autoprefixer ) { %>
-    "grunt-autoprefixer": "^2.2.0",<% } %>
+    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
+    "autoprefixer-core": "^5.2.1",
+    "grunt-postcss": "^0.5.3",<% } %>
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -46,7 +46,8 @@ module.exports = function( grunt ) {
 		<% if ( opts.sass ) { %>
 		sass:   {
 			options: {
-				precision: 2
+				precision: 2,
+				sourceMap: true
 			},
 			all: {
 				files: {
@@ -56,10 +57,12 @@ module.exports = function( grunt ) {
 		},
 		<% } %>
 		<% if ( opts.autoprefixer ) { %>
-		autoprefixer: {
+		postcss: {
 			dist: {
 				options: {
-					browsers: [ 'last 1 version', '> 1%', 'ie 8' ]
+					processors: [
+						require('autoprefixer-core')({browsers: 'last 2 versions'})
+					]
 				},
 				files: { <% if ( opts.sass ) { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/<%= fileSlug %>.css' ]<% } else { %>
@@ -182,12 +185,16 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin', 'wp_readme_to_markdown' ] );
+	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
 	<% } else if ( opts.autoprefixer ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'autoprefixer', 'cssmin', 'wp_readme_to_markdown' ] );
+	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin', 'wp_readme_to_markdown' ] );
+	grunt.registerTask( 'css', ['cssmin'] );
 	<% } %>
+
+	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
+
+	grunt.registerTask( 'default', ['css', 'js', 'wp_readme_to_markdown' ] );
 
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 

--- a/plugin/templates/grunt/_package.json
+++ b/plugin/templates/grunt/_package.json
@@ -17,8 +17,9 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.8.0",<% if ( opts.sass ) { %>
-    "grunt-contrib-sass": "^0.9.2",<% } if ( opts.autoprefixer ) { %>
-    "grunt-autoprefixer": "^2.2.0",<% } %>
+    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
+    "autoprefixer-core": "^5.2.1",
+    "grunt-postcss": "^0.5.3",<% } %>
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -47,7 +47,8 @@ module.exports = function( grunt ) {
 		sass:   {
 			all: {
 				options: {
-					precision: 2
+					precision: 2,
+					sourceMap: true
 				},
 				files: {
 					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
@@ -176,12 +177,16 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'sass', 'autoprefixer', 'cssmin' ] );
+	grunt.registerTrask( 'css', ['sass', 'postcss', 'cssmin'] );
 	<% } else if ( opts.autoprefixer ) { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'autoprefixer', 'cssmin' ] );
+	grunt.registerTask( 'css', ['postcss', 'cssmin' ] );
 	<% } else { %>
-	grunt.registerTask( 'default', ['jshint', 'concat', 'uglify', 'cssmin' ] );
+	grunt.registerTask( 'css', ['cssmin'] );
 	<% } %>
+
+	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
+
+	grunt.registerTask( 'default', ['css', 'js'] );
 
 	grunt.registerTask( 'build', ['default', 'clean', 'copy', 'compress'] );
 

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -177,9 +177,9 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTrask( 'css', ['sass', 'postcss', 'cssmin'] );
+	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
 	<% } else if ( opts.autoprefixer ) { %>
-	grunt.registerTask( 'css', ['postcss', 'cssmin' ] );
+	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
 	grunt.registerTask( 'css', ['cssmin'] );
 	<% } %>

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -56,10 +56,12 @@ module.exports = function( grunt ) {
 		},
 		<% } %>
 		<% if ( opts.autoprefixer ) { %>
-		autoprefixer: {
+		postcss: {
 			dist: {
 				options: {
-					browsers: [ 'last 1 version', '> 1%', 'ie 8' ]
+					processors: [
+						require('autoprefixer-core')({browsers: 'last 2 versions'})
+					]
 				},
 				files: { <% if ( opts.sass ) { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/<%= fileSlug %>.css' ]<% } else { %>

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -17,8 +17,9 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.8.0",<% if ( opts.sass ) { %>
-    "grunt-contrib-sass": "^0.9.2",<% } if ( opts.autoprefixer ) { %>
-    "grunt-autoprefixer": "^2.2.0",<% } %>
+    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
+    "autoprefixer-core": "^5.2.1",
+    "grunt-postcss": "^0.5.3",<% } %>
     "grunt-contrib-cssmin": "^0.12.2",
     "grunt-contrib-jshint": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
This replaces grunt-contrib-sass (using ruby sass) with grunt-sass (using libsass). It also replaces grunt-autoprefixer with postcss/autoprefixer-core due to grunt-autoprefixer being deprecated. 

In addition, sub tasks were made for running "grunt css" and "grunt js". 
