### PR TITLE
add trailing slash to copy tasks for grunt files

### DIFF
--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function( grunt ) {
 					'!release/**',
 					'!assets/css/sass/**',
 					'!assets/css/src/**',
-					'!assetsjs/src/**',
+					'!assets/js/src/**',
 					'!images/src/**',
 					'!bootstrap.php',
 					'!bower.json',

--- a/library/templates/grunt/_Gruntfile.js
+++ b/library/templates/grunt/_Gruntfile.js
@@ -100,7 +100,7 @@ module.exports = function( grunt ) {
 					'!release/**',
 					'!assets/css/sass/**',
 					'!assets/css/src/**',
-					'!assetsjs/src/**',
+					'!assets/js/src/**',
 					'!images/src/**',
 					'!bootstrap.php',
 					'!bower.json',

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function( grunt ) {
 					'!release/**',
 					'!assets/css/sass/**',
 					'!assets/css/src/**',
-					'!assetsjs/src/**',
+					'!assets/js/src/**',
 					'!images/src/**',
 					'!bootstrap.php',
 					'!bower.json',

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -131,7 +131,7 @@ module.exports = function( grunt ) {
 					'!release/**',
 					'!assets/css/sass/**',
 					'!assets/css/src/**',
-					'!assetsjs/src/**',
+					'!assets/js/src/**',
 					'!images/src/**',
 					'!bootstrap.php',
 					'!bower.json',


### PR DESCRIPTION
The _Gruntfile.js file for each generator option is missing a trailing slash in the copy task.
