### PR TITLE
Autoprefixer 6, Grunt PostCSS 0.6.0

### DIFF
--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function( grunt ) {
 			dist: {
 				options: {
 					processors: [
-						require('autoprefixer-core')({browsers: 'last 2 versions'})
+						require('autoprefixer')({browsers: 'last 2 versions'})
 					]
 				},
 				files: { <% if ( opts.sass ) { %>

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -18,8 +18,8 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer-core": "^5.2.1",
-    "grunt-postcss": "^0.5.4",<% } %>
+    "autoprefixer": "^6.0.0",
+    "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function( grunt ) {
 			dist: {
 				options: {
 					processors: [
-						require('autoprefixer-core')({browsers: 'last 2 versions'})
+						require('autoprefixer')({browsers: 'last 2 versions'})
 					]
 				},
 				files: { <% if ( opts.sass ) { %>

--- a/plugin/templates/grunt/_package.json
+++ b/plugin/templates/grunt/_package.json
@@ -18,8 +18,8 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer-core": "^5.2.1",
-    "grunt-postcss": "^0.5.4",<% } %>
+    "autoprefixer": "^6.0.0",
+    "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function( grunt ) {
 			dist: {
 				options: {
 					processors: [
-						require('autoprefixer-core')({browsers: 'last 2 versions'})
+						require('autoprefixer')({browsers: 'last 2 versions'})
 					]
 				},
 				files: { <% if ( opts.sass ) { %>

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -18,8 +18,8 @@
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer-core": "^5.2.1",
-    "grunt-postcss": "^0.5.4",<% } %>
+    "autoprefixer": "^6.0.0",
+    "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",


### PR DESCRIPTION
Adds PostCSS 5.0 API.
Adds custom syntaxes support.
Adds image-set support (by 一丝).
Adds mask-border support (by 一丝).
Adds filter() function support (by Vincent De Oliveira).
Adds backdrop-filter support (by Vincent De Oliveira).
Adds element() support (by Vincent De Oliveira).
Adds CSS Regions support.
Adds Scroll Snap Points support.
Adds writing-mode support.
Adds ::backdrop support.
Adds cross-fade() support.
Adds other break- properties support.
Adds Microsoft Edge support (by Andrey Polischuk).
Adds not keyword and exclude browsers by query.
Adds version ranges IE 6-9 (by Ben Briggs).
Fixs filter in transition support on Safari.
Fixs url() parsing.
Fixs pixelated cleaning.
Removes safe option. Use separated Safe parser from PostCSS.
Removes Opera 12.1 from default query.
Updated autoprefixer-core merged into autoprefixer
