### PR TITLE
Update/postcss

### DIFF
--- a/child-theme/index.js
+++ b/child-theme/index.js
@@ -145,6 +145,7 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 	css: function() {
 		if ( this.opts.sass ) {
 			this.template( 'css/_style.css', 'assets/css/sass/' + this.fileSlug + '.scss' );
+			this.template( 'css/_style.oldie.scss', 'assets/css/sass/' + this.fileSlug + '.oldie.scss' );
 		} else if ( this.opts.postcss ) {
 			this.template( 'css/_style.css', 'assets/css/src/' + this.fileSlug + '.css' );
 		} else {

--- a/child-theme/index.js
+++ b/child-theme/index.js
@@ -98,10 +98,10 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 		}.bind( this ) );
 	},
 
-	autoprefixer: function() {
-		// If we're running Sass, automatically use autoprefixer.
+	postcss: function() {
+		// If we're running Sass, automatically use postcss.
 		if ( this.opts.sass ) {
-			this.opts.autoprefixer = true;
+			this.opts.postcss = true;
 			return;
 		}
 
@@ -109,12 +109,12 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 		var done = this.async();
 		this.prompt( [{
 			type:    'confirm',
-			name:    'autoprefixer',
-			message: 'Use Autoprefixer?',
+			name:    'postcss',
+			message: 'Use PostCSS?',
 			default: true
 		}],
 		function( props ){
-			this.opts.autoprefixer = props.autoprefixer;
+			this.opts.postcss = props.postcss;
 			done();
 		}.bind( this ) );
 	},
@@ -145,7 +145,7 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 	css: function() {
 		if ( this.opts.sass ) {
 			this.template( 'css/_style.css', 'assets/css/sass/' + this.fileSlug + '.scss' );
-		} else if ( this.opts.autoprefixer ) {
+		} else if ( this.opts.postcss ) {
 			this.template( 'css/_style.css', 'assets/css/src/' + this.fileSlug + '.css' );
 		} else {
 			this.template( 'css/_style.css', 'assets/css/' + this.fileSlug + '.css' );

--- a/child-theme/templates/css/_style.oldie.scss
+++ b/child-theme/templates/css/_style.oldie.scss
@@ -1,0 +1,11 @@
+/**
+ * <%= opts.projectTitle %>
+ * <%= opts.projectHome %>
+ *
+ * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
+ * Licensed under the GPLv2+ license.
+ */
+
+$oldie: true;
+
+@import "<%= opts.projectSlug %>.scss";

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -51,7 +51,8 @@ module.exports = function( grunt ) {
 					sourceMap: true
 				},
 				files: {
-					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
+					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss',
+					'assets/css/<%= fileSlug %>.oldie.css': 'assets/css/sass/<%= fileSlug %>.oldie.scss'
 				}
 			}
 		},
@@ -65,12 +66,33 @@ module.exports = function( grunt ) {
 						annotation: 'assets/css/'
 					},
 					processors: [
-						require('autoprefixer')({browsers: 'last 2 versions'})
+						require('autoprefixer')({browsers: 'last 2 versions'}),
+						require('cssnano')()
 					]
 				},
 				files: { <% if ( opts.sass ) { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/<%= fileSlug %>.css' ]<% } else { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/src/<%= fileSlug %>.css' ]<% } %>
+				}
+			},
+			oldie: {
+				options: {
+					processors: [
+						require('postcss-unmq')({
+							width: 1024
+						}),
+						require('autoprefixer')({
+							browsers: 'ie >= 8'
+						}),
+						require('pixrem')(),
+						require('postcss-opacity')(),
+						require('postcss-pseudoelements')(),
+						require('cssnano')()
+					]
+				},
+				files: { <% if ( opts.sass ) { %>
+					'assets/css/<%= fileSlug %>.oldie.css': [ 'assets/css/<%= fileSlug %>.oldie.css' ]<% } else { %>
+					'assets/css/<%= fileSlug %>.oldie.css': [ 'assets/css/src/<%= fileSlug %>.css' ]<% } %>
 				}
 			}
 		},
@@ -91,7 +113,7 @@ module.exports = function( grunt ) {
 				src: ['<%= fileSlug %>.css'],
 
 				dest: 'assets/css/',
-				ext: '.min.css'
+				ext: '.css'
 			}
 		},
 		watch:  {
@@ -102,12 +124,10 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
-				files: ['assets/css/src/*.css'],
-				tasks: ['postcss', 'cssmin'],<% } else { %>
-				files: ['assets/css/*.css', '!assets/css/*.min.css'],
-				tasks: ['cssmin'],<% } %>
+				files: ['assets/css/sass/**/*.scss'],<% } else if ( opts.postcss ) { %>
+				files: ['assets/css/src/*.css'],<% } else { %>
+				files: ['assets/css/*.css'],<% } %>
+				tasks: ['css'],
 				options: {
 					debounceDelay: 500
 				}
@@ -183,12 +203,9 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.postcss ) { %>
-	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
-	<% } else { %>
-	grunt.registerTask( 'css', ['cssmin'] );
-	<% } %>
+	grunt.registerTask( 'css', ['sass', 'postcss'] );<% } else if ( opts.postcss ) { %>
+	grunt.registerTask( 'css', ['postcss'] );<% } else { %>
+	grunt.registerTask( 'css', ['cssmin'] );<% } %>
 
 	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
 

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function( grunt ) {
 			}
 		},
 		<% } %>
-		<% if ( opts.autoprefixer ) { %>
+		<% if ( opts.postcss ) { %>
 		postcss: {
 			dist: {
 				options: {
@@ -99,9 +99,9 @@ module.exports = function( grunt ) {
 			},
 			styles: { <% if ( opts.sass ) { %>
 				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
+				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
 				files: ['assets/css/src/*.css'],
-				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
+				tasks: ['postcss', 'cssmin'],<% } else { %>
 				files: ['assets/css/*.css', '!assets/css/*.min.css'],
 				tasks: ['cssmin'],<% } %>
 				options: {
@@ -180,7 +180,7 @@ module.exports = function( grunt ) {
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.autoprefixer ) { %>
+	<% } else if ( opts.postcss ) { %>
 	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
 	grunt.registerTask( 'css', ['cssmin'] );

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -60,6 +60,10 @@ module.exports = function( grunt ) {
 		postcss: {
 			dist: {
 				options: {
+					map: {
+						inline: false,
+						annotation: 'assets/css/'
+					},
 					processors: [
 						require('autoprefixer')({browsers: 'last 2 versions'})
 					]

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -19,8 +19,12 @@
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.postcss ) { %>
     "autoprefixer": "^6.0.2",
-    "grunt-postcss": "^0.6.0",<% } %>
-    "grunt-contrib-cssmin": "^0.12.3",
+    "cssnano": "^3.0.1",
+    "grunt-postcss": "^0.6.0",
+    "pixrem": "^2.0.0",
+    "postcss-opacity": "^3.0.0",
+    "postcss-pseudoelements": "^3.0.0",
+    "postcss-unmq": "^1.0.0",<% } %>
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-clean": "^0.6.0",

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -17,8 +17,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
-    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer": "^6.0.0",
+    "grunt-sass": "^1.0.0",<% } if ( opts.postcss ) { %>
+    "autoprefixer": "^6.0.2",
     "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -94,10 +94,10 @@ var PluginGenerator = yeoman.generators.Base.extend({
 		}.bind( this ));
 	},
 
-	autoprefixer: function() {
-		// If we're running Sass, automatically use autoprefixer.
+	postcss: function() {
+		// If we're running Sass, automatically use postcss.
 		if ( this.opts.sass ) {
-			this.opts.autoprefixer = true;
+			this.opts.postcss = true;
 			return;
 		}
 
@@ -105,12 +105,12 @@ var PluginGenerator = yeoman.generators.Base.extend({
 		var done = this.async();
 		this.prompt( [{
 			type:    'confirm',
-			name:    'autoprefixer',
-			message: 'Use Autoprefixer?',
+			name:    'postcss',
+			message: 'Use PostCSS?',
 			default: true
 		}],
 		function( props ){
-			this.opts.autoprefixer = props.autoprefixer;
+			this.opts.postcss = props.postcss;
 			done();
 		}.bind( this ));
 	},
@@ -139,7 +139,7 @@ var PluginGenerator = yeoman.generators.Base.extend({
 	css: function() {
 		if ( this.opts.sass ) {
 			this.template( 'css/_style.css', 'assets/css/sass/' + this.fileSlug + '.scss' );
-		} else if ( this.opts.autoprefixer ) {
+		} else if ( this.opts.postcss ) {
 			this.template( 'css/_style.css', 'assets/css/src/' + this.fileSlug + '.css' );
 		} else {
 			this.template( 'css/_style.css', 'assets/css/' + this.fileSlug + '.css' );

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -25,7 +25,7 @@ var PluginGenerator = yeoman.generators.Base.extend({
 					installs.push( _install( installers[ i ],this ));
 				}
 			}
-			
+
 			if ( 0 < chalks.skipped.length ) {
 				this.log( 'Skipping ' + chalks.skipped.join( ', ' ) + '. Just run yourself when you are ready.' );
 			}
@@ -88,7 +88,7 @@ var PluginGenerator = yeoman.generators.Base.extend({
 			this.opts.projectSlug = this.opts.projectTitle.toLowerCase().replace( /[\s]/g, '-' ).replace( /[^a-z-_]/g, '' );
 			this.fileSlug = this.opts.projectSlug;
 			this.namespace = this.opts.projectTitle.replace( /[\s|-]/g, '_' ).replace( /( ^|_ )( [a-z] )/g, function( match, group1, group2 ){
-				return group1 + group2.toUpperCase(); 
+				return group1 + group2.toUpperCase();
 			});
 			done();
 		}.bind( this ));

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -102,12 +102,10 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
-				files: ['assets/css/src/*.css'],
-				tasks: ['postcss', 'cssmin'],<% } else { %>
-				files: ['assets/css/*.css', '!assets/css/*.min.css'],
-				tasks: ['cssmin'],<% } %>
+				files: ['assets/css/sass/**/*.scss'],<% } else if ( opts.postcss ) { %>
+				files: ['assets/css/src/*.css'],<% } else { %>
+				files: ['assets/css/*.css'],<% } %>
+				tasks: ['css'],
 				options: {
 					debounceDelay: 500
 				}
@@ -190,12 +188,9 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.postcss ) { %>
-	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
-	<% } else { %>
-	grunt.registerTask( 'css', ['cssmin'] );
-	<% } %>
+	grunt.registerTask( 'css', ['sass', 'postcss'] );<% } else if ( opts.postcss ) { %>
+	grunt.registerTask( 'css', ['postcss'] );<% } else { %>
+	grunt.registerTask( 'css', ['cssmin'] );<% } %>
 
 	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
 

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -56,7 +56,7 @@ module.exports = function( grunt ) {
 			}
 		},
 		<% } %>
-		<% if ( opts.autoprefixer ) { %>
+		<% if ( opts.postcss ) { %>
 		postcss: {
 			dist: {
 				options: {
@@ -99,9 +99,9 @@ module.exports = function( grunt ) {
 			},
 			styles: { <% if ( opts.sass ) { %>
 				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
+				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
 				files: ['assets/css/src/*.css'],
-				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
+				tasks: ['postcss', 'cssmin'],<% } else { %>
 				files: ['assets/css/*.css', '!assets/css/*.min.css'],
 				tasks: ['cssmin'],<% } %>
 				options: {
@@ -187,7 +187,7 @@ module.exports = function( grunt ) {
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.autoprefixer ) { %>
+	<% } else if ( opts.postcss ) { %>
 	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
 	grunt.registerTask( 'css', ['cssmin'] );

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -60,6 +60,10 @@ module.exports = function( grunt ) {
 		postcss: {
 			dist: {
 				options: {
+					map: {
+						inline: false,
+						annotation: 'assets/css/'
+					},
 					processors: [
 						require('autoprefixer')({browsers: 'last 2 versions'})
 					]

--- a/plugin/templates/grunt/_package.json
+++ b/plugin/templates/grunt/_package.json
@@ -17,8 +17,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
-    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer": "^6.0.0",
+    "grunt-sass": "^1.0.0",<% } if ( opts.postcss ) { %>
+    "autoprefixer": "^6.0.2",
     "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",

--- a/shared/css/readme.md
+++ b/shared/css/readme.md
@@ -1,3 +1,3 @@
 # Styles
 
-Only final CSS styles should exist in this folder.  If you are using SASS, LESS, autoprefixer, or some other pre-processor, please place your raw source files in a subdirectory.
+Only final CSS styles should exist in this folder.  If you are using SASS, LESS, PostCSS, or some other pre-processor, please place your raw source files in a subdirectory.

--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -71,14 +71,24 @@ function scripts( $debug = false ) {
  * @return void
  */
 function styles( $debug = false ) {
-	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
 	wp_enqueue_style(
 		'<%= opts.funcPrefix %>',
-		<%= opts.funcPrefix.toUpperCase() %>_URL . "/assets/css/<%= fileSlug %>{$min}.css",
+		<%= opts.funcPrefix.toUpperCase() %>_URL . "/assets/css/<%= fileSlug %>.css",
+		array(),
+		<%= opts.funcPrefix.toUpperCase() %>_VERSION,
+		'screen, handheld, tv, projection'
+	);
+
+	wp_enqueue_style(
+		'<%= opts.funcPrefix %>-oldie',
+		<%= opts.funcPrefix.toUpperCase() %>_URL . "/assets/css/<%= fileSlug %>.oldie.css",
 		array(),
 		<%= opts.funcPrefix.toUpperCase() %>_VERSION
 	);
+
+	global $wp_styles;
+
+	$wp_styles->add_data( '<%= opts.funcPrefix %>-oldie', 'conditional', 'lte IE 8' );
 }
 
 /**

--- a/theme/index.js
+++ b/theme/index.js
@@ -25,7 +25,7 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 					installs.push( _install( installers[ i ],this ));
 				}
 			}
-			
+
 			if ( 0 < chalks.skipped.length ) {
 				this.log( 'Skipping ' + chalks.skipped.join( ', ' ) + '. Just run yourself when you are ready.' );
 			}

--- a/theme/index.js
+++ b/theme/index.js
@@ -144,6 +144,7 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 	css: function() {
 		if ( this.opts.sass ) {
 			this.template( 'css/_style.css', 'assets/css/sass/' + this.fileSlug + '.scss' );
+			this.template( 'css/_style.oldie.scss', 'assets/css/sass/' + this.fileSlug + '.oldie.scss' );
 		} else if ( this.opts.postcss ) {
 			this.template( 'css/_style.css', 'assets/css/src/' + this.fileSlug + '.css' );
 		} else {

--- a/theme/index.js
+++ b/theme/index.js
@@ -94,10 +94,10 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 		}.bind( this ));
 	},
 
-	autoprefixer: function() {
-		// If we're running Sass, automatically use autoprefixer.
+	postcss: function() {
+		// If we're running Sass, automatically use postcss.
 		if ( this.opts.sass ) {
-			this.opts.autoprefixer = true;
+			this.opts.postcss = true;
 			return;
 		}
 
@@ -105,12 +105,12 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 		var done = this.async();
 		this.prompt( [{
 			type:    'confirm',
-			name:    'autoprefixer',
-			message: 'Use Autoprefixer?',
+			name:    'postcss',
+			message: 'Use PostCSS?',
 			default: true
 		}],
 		function( props ){
-			this.opts.autoprefixer = props.autoprefixer;
+			this.opts.postcss = props.postcss;
 			done();
 		}.bind( this ));
 	},
@@ -144,7 +144,7 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 	css: function() {
 		if ( this.opts.sass ) {
 			this.template( 'css/_style.css', 'assets/css/sass/' + this.fileSlug + '.scss' );
-		} else if ( this.opts.autoprefixer ) {
+		} else if ( this.opts.postcss ) {
 			this.template( 'css/_style.css', 'assets/css/src/' + this.fileSlug + '.css' );
 		} else {
 			this.template( 'css/_style.css', 'assets/css/' + this.fileSlug + '.css' );

--- a/theme/templates/css/_style.oldie.scss
+++ b/theme/templates/css/_style.oldie.scss
@@ -1,0 +1,11 @@
+/**
+ * <%= opts.projectTitle %>
+ * <%= opts.projectHome %>
+ *
+ * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
+ * Licensed under the GPLv2+ license.
+ */
+
+$oldie: true;
+
+@import "<%= opts.projectSlug %>.scss";

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -51,7 +51,8 @@ module.exports = function( grunt ) {
 					sourceMap: true
 				},
 				files: {
-					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss'
+					'assets/css/<%= fileSlug %>.css': 'assets/css/sass/<%= fileSlug %>.scss',
+					'assets/css/<%= fileSlug %>.oldie.css': 'assets/css/sass/<%= fileSlug %>.oldie.scss'
 				}
 			}
 		},
@@ -65,12 +66,33 @@ module.exports = function( grunt ) {
 						annotation: 'assets/css/'
 					},
 					processors: [
-						require('autoprefixer')({browsers: 'last 2 versions'})
+						require('autoprefixer')({browsers: 'last 2 versions'}),
+						require('cssnano')()
 					]
 				},
 				files: { <% if ( opts.sass ) { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/<%= fileSlug %>.css' ]<% } else { %>
 					'assets/css/<%= fileSlug %>.css': [ 'assets/css/src/<%= fileSlug %>.css' ]<% } %>
+				}
+			},
+			oldie: {
+				options: {
+					processors: [
+						require('postcss-unmq')({
+							width: 1024
+						}),
+						require('autoprefixer')({
+							browsers: 'ie >= 8'
+						}),
+						require('pixrem')(),
+						require('postcss-opacity')(),
+						require('postcss-pseudoelements')(),
+						require('cssnano')()
+					]
+				},
+				files: { <% if ( opts.sass ) { %>
+					'assets/css/<%= fileSlug %>.oldie.css': [ 'assets/css/<%= fileSlug %>.oldie.css' ]<% } else { %>
+					'assets/css/<%= fileSlug %>.oldie.css': [ 'assets/css/src/<%= fileSlug %>.css' ]<% } %>
 				}
 			}
 		},
@@ -90,7 +112,7 @@ module.exports = function( grunt ) {
 				src: ['<%= fileSlug %>.css'],
 
 				dest: 'assets/css/',
-				ext: '.min.css'
+				ext: '.css'
 			}
 		},
 		watch:  {
@@ -101,12 +123,10 @@ module.exports = function( grunt ) {
 				}
 			},
 			styles: { <% if ( opts.sass ) { %>
-				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
-				files: ['assets/css/src/*.css'],
-				tasks: ['postcss', 'cssmin'],<% } else { %>
-				files: ['assets/css/*.css', '!assets/css/*.min.css'],
-				tasks: ['cssmin'],<% } %>
+				files: ['assets/css/sass/**/*.scss'],<% } else if ( opts.postcss ) { %>
+				files: ['assets/css/src/*.css'],<% } else { %>
+				files: ['assets/css/*.css'],<% } %>
+				tasks: ['css'],
 				options: {
 					debounceDelay: 500
 				}
@@ -183,12 +203,9 @@ module.exports = function( grunt ) {
 
 	// Register tasks
 	<% if ( opts.sass ) { %>
-	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.postcss ) { %>
-	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
-	<% } else { %>
-	grunt.registerTask( 'css', ['cssmin'] );
-	<% } %>
+	grunt.registerTask( 'css', ['sass', 'postcss'] );<% } else if ( opts.postcss ) { %>
+	grunt.registerTask( 'css', ['postcss'] );<% } else { %>
+	grunt.registerTask( 'css', ['cssmin'] );<% } %>
 
 	grunt.registerTask( 'js', ['jshint', 'concat', 'uglify'] );
 

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -56,10 +56,14 @@ module.exports = function( grunt ) {
 			}
 		},
 		<% } %>
-		<% if ( opts.autoprefixer ) { %>
+		<% if ( opts.postcss ) { %>
 		postcss: {
 			dist: {
 				options: {
+					map: {
+						inline: false,
+						annotation: 'assets/css/'
+					},
 					processors: [
 						require('autoprefixer')({browsers: 'last 2 versions'})
 					]
@@ -98,9 +102,9 @@ module.exports = function( grunt ) {
 			},
 			styles: { <% if ( opts.sass ) { %>
 				files: ['assets/css/sass/**/*.scss'],
-				tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
+				tasks: ['sass', 'postcss', 'cssmin'],<% } else if ( opts.postcss ) { %>
 				files: ['assets/css/src/*.css'],
-				tasks: ['autoprefixer', 'cssmin'],<% } else { %>
+				tasks: ['postcss', 'cssmin'],<% } else { %>
 				files: ['assets/css/*.css', '!assets/css/*.min.css'],
 				tasks: ['cssmin'],<% } %>
 				options: {
@@ -180,7 +184,7 @@ module.exports = function( grunt ) {
 	// Register tasks
 	<% if ( opts.sass ) { %>
 	grunt.registerTask( 'css', ['sass', 'postcss', 'cssmin'] );
-	<% } else if ( opts.autoprefixer ) { %>
+	<% } else if ( opts.postcss ) { %>
 	grunt.registerTask( 'css', ['postcss', 'cssmin'] );
 	<% } else { %>
 	grunt.registerTask( 'css', ['cssmin'] );

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -19,8 +19,12 @@
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.postcss ) { %>
     "autoprefixer": "^6.0.2",
-    "grunt-postcss": "^0.6.0",<% } %>
-    "grunt-contrib-cssmin": "^0.12.3",
+    "cssnano": "^3.0.1",
+    "grunt-postcss": "^0.6.0",
+    "pixrem": "^2.0.0",
+    "postcss-opacity": "^3.0.0",
+    "postcss-pseudoelements": "^3.0.0",
+    "postcss-unmq": "^1.0.0",<% } %>
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-clean": "^0.6.0",

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -17,8 +17,8 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
-    "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>
-    "autoprefixer": "^6.0.0",
+    "grunt-sass": "^1.0.0",<% } if ( opts.postcss ) { %>
+    "autoprefixer": "^6.0.2",
     "grunt-postcss": "^0.6.0",<% } %>
     "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "^0.11.2",


### PR DESCRIPTION
A major update to how (S)CSS files are handled. This changes the option of **Autoprefixer** to  **PostCSS** and provides the following improvements:
- Added: Source maps for CSS files
- Added: Alternative CSS for old Internet Explorer
- Added: Alternative SCSS variable for old Internet Explorer, `$oldie`
- Added: Old IE CSS automatically unwraps or removes (non-)desktop media queries
- Added: Old IE CSS automatically transpiles rem to compatible px units
- Added: Old IE CSS automatically transpiles opacity to compatible ms-filter property
- Added: Old IE CSS automatically transpiles `::` to compatible `:` pseudo-elements in a selector
- Updates: Autoprefixer dependency
- Fixes: incorrectly linked PostCSS tasks in Gruntfile.js
- Changes: Autoprefixer option to PostCSS option
- Changes: Creates only one minified CSS file

These changes are based on successful practices I’ve seen leveraged by other 10up developers and of which I have been using as well.
