### PR TITLE
Remove GPL declarations

### DIFF
--- a/child-theme/templates/composer/_composer.json
+++ b/child-theme/templates/composer/_composer.json
@@ -5,7 +5,6 @@
 	"type": "wordpress-theme",
 	"keywords": [],
 	<% if ( opts.projectHome ) { %>"homepage": "<%= opts.projectHome %>",<% } %>
-	"license": "GPLv2.0+",
 	"authors": [
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",

--- a/child-theme/templates/css/_style.css
+++ b/child-theme/templates/css/_style.css
@@ -3,7 +3,6 @@
  * <%= opts.projectHome %>
  *
  * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * Licensed under the GPLv2+ license.
  */
 
 @import url('../../../<%= opts.parentSlug %>/style.css');

--- a/child-theme/templates/grunt/_Gruntfile.js
+++ b/child-theme/templates/grunt/_Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%= pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n'
 			},
 			main: {
@@ -35,7 +34,6 @@ module.exports = function( grunt ) {
 					banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 						' * <%%= pkg.homepage %>\n' +
 						' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-						' * Licensed GPLv2+' +
 						' */\n',
 					mangle: {
 						except: ['jQuery']
@@ -76,7 +74,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%=pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n',
 				processImport: false
 			},

--- a/child-theme/templates/theme/_style.css
+++ b/child-theme/templates/theme/_style.css
@@ -8,9 +8,6 @@
  * Version:     0.1.0
  * Tags:
  * Text Domain: <%= opts.funcPrefix %>
- *
- * License:     GPLv2+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 /**

--- a/library/templates/grunt/_Gruntfile.js
+++ b/library/templates/grunt/_Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%= pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n'
 			},
 			main: {
@@ -35,7 +34,6 @@ module.exports = function( grunt ) {
 					banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 						' * <%%= pkg.homepage %>\n' +
 						' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-						' * Licensed GPLv2+' +
 						' */\n',
 					mangle: {
 						except: ['jQuery']
@@ -48,7 +46,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%=pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n',
 				processImport: false
 			},

--- a/plugin/templates/composer/_composer.json
+++ b/plugin/templates/composer/_composer.json
@@ -5,7 +5,6 @@
 	"type": "wordpress-plugin",
 	"keywords": [],
 	<% if ( opts.projectHome ) { %>"homepage": "<%= opts.projectHome %>",<% } %>
-	"license": "GPLv2.0+",
 	"authors": [
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",

--- a/plugin/templates/css/_style.css
+++ b/plugin/templates/css/_style.css
@@ -3,5 +3,4 @@
  * <%= opts.projectHome %>
  *
  * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * Licensed under the GPLv2+ license.
  */

--- a/plugin/templates/grunt/_Gruntfile.js
+++ b/plugin/templates/grunt/_Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%= pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n'
 			},
 			main: {
@@ -35,7 +34,6 @@ module.exports = function( grunt ) {
 					banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 						' * <%%= pkg.homepage %>\n' +
 						' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-						' * Licensed GPLv2+' +
 						' */\n',
 					mangle: {
 						except: ['jQuery']
@@ -76,7 +74,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%=pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n',
 				processImport: false
 			},

--- a/plugin/templates/plugin/_plugin.php
+++ b/plugin/templates/plugin/_plugin.php
@@ -6,7 +6,6 @@
  * Version:     0.1.0
  * Author:      <%= opts.authorName %>
  * Author URI:  <%= opts.authorUrl %>
- * License:     GPLv2+
  * Text Domain: <%= opts.funcPrefix %>
  * Domain Path: /languages
  */

--- a/plugin/templates/plugin/_readme.txt
+++ b/plugin/templates/plugin/_readme.txt
@@ -5,8 +5,6 @@ Tags:
 Requires at least: 4.1.1
 Tested up to:      4.1.1
 Stable tag:        0.1.0
-License:           GPLv2 or later
-License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
 <%= opts.description %>
 

--- a/shared/bower/_bower.json
+++ b/shared/bower/_bower.json
@@ -2,7 +2,6 @@
   "name": "<%= opts.projectSlug %>",
   "version": "0.0.1",
   "main": "/",
-  "license": "GPLv2+",
   "ignore": [
     "**/.*",
     "*.md",

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -3,7 +3,6 @@
  * <%= opts.projectHome %>
  *
  * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * Licensed under the GPLv2+ license.
  */
 
 ( function( window, undefined ) {

--- a/theme/templates/composer/_composer.json
+++ b/theme/templates/composer/_composer.json
@@ -5,7 +5,6 @@
 	"type": "wordpress-theme",
 	"keywords": [],
 	<% if ( opts.projectHome ) { %>"homepage": "<%= opts.projectHome %>",<% } %>
-	"license": "GPLv2.0+",
 	"authors": [
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",

--- a/theme/templates/css/_style.css
+++ b/theme/templates/css/_style.css
@@ -3,5 +3,4 @@
  * <%= opts.projectHome %>
  *
  * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * Licensed under the GPLv2+ license.
  */

--- a/theme/templates/grunt/_Gruntfile.js
+++ b/theme/templates/grunt/_Gruntfile.js
@@ -9,7 +9,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%= pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n'
 			},
 			main: {
@@ -35,7 +34,6 @@ module.exports = function( grunt ) {
 					banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 						' * <%%= pkg.homepage %>\n' +
 						' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-						' * Licensed GPLv2+' +
 						' */\n',
 					mangle: {
 						except: ['jQuery']
@@ -76,7 +74,6 @@ module.exports = function( grunt ) {
 				banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 					' * <%%=pkg.homepage %>\n' +
 					' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-					' * Licensed GPLv2+' +
 					' */\n'
 			},
 			minify: {

--- a/theme/templates/theme/_style.css
+++ b/theme/templates/theme/_style.css
@@ -7,9 +7,6 @@
  * Version:     0.1.0
  * Tags:
  * Text Domain: <%= opts.funcPrefix %>
- *
- * License:     GPLv2+
- * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  */
 
 /**


### PR DESCRIPTION
Based on a conversation with @jeckman, I think we should take GPL declarations out of the generated theme. GPL comes into play when code is distributed, and there's no guarantee the client/recipient of the theme will be re-distributing it beyond their own internal use. A default license declaration like this can be counterproductive for agencies developing WordPress themes.
