### PR TITLE
Update watch tasks to match regular tasks

### DIFF
--- a/shared/grunt/tasks/options/_watch.js
+++ b/shared/grunt/tasks/options/_watch.js
@@ -5,20 +5,18 @@ module.exports = {
 			livereload: true
 		}
 	},
-	styles: { <% if ( opts.sass ) { %>
-		files: ['assets/css/sass/**/*.scss'],
-		tasks: ['sass', 'autoprefixer', 'cssmin'],<% } else if ( opts.autoprefixer ) { %>
-		files: ['assets/css/src/*.css'],
-		tasks: ['autoprefixer', 'cssmin'],<% } else { %>
-		files: ['assets/css/*.css', '!assets/css/*.min.css'],
-		tasks: ['cssmin'],<% } %>
+	css: {
+		<% if ( opts.sass ) { %>files: ['assets/css/sass/**/*.scss'],<% } %>
+		<% else if ( opts.autoprefixer ) { %>files: ['assets/css/src/*.css'],<% } %>
+		<% else { %>files: ['assets/css/*.css', '!assets/css/*.min.css'],<% } %>
+		tasks: ['css'],
 		options: {
 			debounceDelay: 500
 		}
 	},
-	scripts: {
+	js: {
 		files: ['assets/js/src/**/*.js', 'assets/js/vendor/**/*.js'],
-			tasks: ['jshint', 'concat', 'uglify'],
+			tasks: ['js'],
 			options: {
 			debounceDelay: 500
 		}


### PR DESCRIPTION
This changes watch tasks to match regular tasks.

This renames the `watch styles` and `watch scripts` subtasks task to be `watch css` and `watch js`, matching the names of the regular `css` and `js` tasks. This way, one does not need to learn multiple names for the same kind of task.

This changes the `watch css` and `watch js` subtasks to reference the regular `css` and `js` tasks. This way, one can modify the `css` or `js` tasks without also needing to duplicate those modifications in the `watch css` and `watch js` subtasks.

As a result, this allows the if statements in the `_watch.js` template to be reduced to only affect the `files` property.
