### PR TITLE
Remove `$debug` parameter from scripts and styles

### DIFF
--- a/shared/tests/phpunit/_Core_Tests.php
+++ b/shared/tests/phpunit/_Core_Tests.php
@@ -29,7 +29,7 @@ class Core_Tests extends Base\TestCase {
 			define( '<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL', 'template_url' );
 		}
 		if ( ! defined( '<%= opts.funcPrefix.toUpperCase() %>_VERSION' ) ) {
-			define( '<%= opts.funcPrefix.toUpperCase() %>_VERSION', '0.0.1' );
+			define( '<%= opts.funcPrefix.toUpperCase() %>_VERSION', '0.1.0' );
 		}
 		if ( ! defined( '<%= opts.funcPrefix.toUpperCase() %>_URL' ) ) {
 			define( '<%= opts.funcPrefix.toUpperCase() %>_URL', 'url' );
@@ -86,7 +86,7 @@ class Core_Tests extends Base\TestCase {
 				'<%= opts.funcPrefix %>',
 				'template_url/assets/js/<%= fileSlug %>.min.js',
 				array(),
-				'0.0.1',
+				'0.1.0',
 				true,
 			),
 		) );
@@ -101,12 +101,15 @@ class Core_Tests extends Base\TestCase {
 				'<%= opts.funcPrefix %>',
 				'template_url/assets/js/<%= fileSlug %>.js',
 				array(),
-				'0.0.1',
+				'0.1.0',
 				true,
 			),
 		) );
+		\WP_Mock::onFilter( 'special_filter' )
+		        ->with( '<%= opts.funcPrefix %>_script_debug' )
+		        ->reply( true );
 
-		scripts( true );
+		scripts();
 		$this->assertConditionsMet();
 	}
 
@@ -121,7 +124,7 @@ class Core_Tests extends Base\TestCase {
 				'<%= opts.funcPrefix %>',
 				'url/assets/css/<%= fileSlug %>.min.css',
 				array(),
-				'0.0.1',
+				'0.1.0',
 			),
 		) );
 
@@ -135,11 +138,14 @@ class Core_Tests extends Base\TestCase {
 				'<%= opts.funcPrefix %>',
 				'url/assets/css/<%= fileSlug %>.css',
 				array(),
-				'0.0.1',
+				'0.1.0',
 			),
 		) );
+		\WP_Mock::onFilter( 'special_filter' )
+		        ->with( '<%= opts.funcPrefix %>_style_debug' )
+		        ->reply( true );
 
-		styles( true );
+		styles();
 		$this->assertConditionsMet();
 	}
 

--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -45,10 +45,15 @@ function i18n() {
  *
  * @since 0.1.0
  *
- * @param bool $debug Whether to enable loading uncompressed/debugging assets. Default false.
  * @return void
  */
-function scripts( $debug = false ) {
+function scripts() {
+	/**
+	 * Flag whether to enable loading uncompressed/debugging assets. Default false.
+	 * 
+	 * @param bool <%= opts.funcPrefix %>_script_debug
+	 */
+	$debug = apply_filters( '<%= opts.funcPrefix %>_script_debug', false );
 	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	wp_enqueue_script(
@@ -67,10 +72,15 @@ function scripts( $debug = false ) {
  *
  * @since 0.1.0
  *
- * @param bool $debug Whether to enable loading uncompressed/debugging assets. Default false.
  * @return void
  */
-function styles( $debug = false ) {
+function styles() {
+	/**
+	 * Flag whether to enable loading uncompressed/debugging assets. Default false.
+	 *
+	 * @param bool <%= opts.funcPrefix %>_style_debug
+	 */
+	$debug = apply_filters( '<%= opts.funcPrefix %>_style_debug', false );
 	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 
 	wp_enqueue_style(


### PR DESCRIPTION
We originally added an optional `$debug` parameter to the functions used to enqueue scripts and styles in order to make them efficiently testable without corrupting constants. Unfortunatately, many people copy-paste these methods as-is without understanding the point of the parameter and/or using tests properly.

To prevent poor copy-pasta code, we're removing the parameter and instead adding filters to both the script and style enqueues to continue to support testability.

Fixes #54
