### PR TITLE
Introduce WP Core's .editorconfig to generators

### DIFF
--- a/child-theme/index.js
+++ b/child-theme/index.js
@@ -126,6 +126,7 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 		this.template( '../../shared/theme/_humans.txt', 'humans.txt' );
 		this.copy( 'theme/screenshot.png', 'screenshot.png' );
 		this.copy( '../../shared/theme/readme-includes.md', 'includes/readme.md' );
+		this.copy( '../../shared/_editorconfig', '.editorconfig' );
 	},
 
 	i18n: function() {

--- a/library/index.js
+++ b/library/index.js
@@ -110,6 +110,7 @@ var LibGenerator = yeoman.generators.Base.extend({
 			this.template( '../../shared/grunt/tasks/_default.js', 'tasks/default.js' );
 			this.template( '../../shared/grunt/tasks/_js.js', 'tasks/js.js' );
 			this.template( '../../shared/grunt/tasks/_test.js', 'tasks/test.js' );
+			this.copy( '../../shared/_editorconfig', '.editorconfig' );
 		},
 
 		bower: function() {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -120,6 +120,7 @@ var PluginGenerator = yeoman.generators.Base.extend({
 		this.template( 'plugin/_plugin.php', this.fileSlug + '.php' );
 		this.template( 'plugin/_core.php', 'includes/functions/core.php' );
 		this.copy( 'plugin/readme-includes.md', 'php/readme.md' );
+		this.copy( '../../shared/_editorconfig', '.editorconfig' );
 	},
 
 	i18n: function() {

--- a/shared/_editorconfig
+++ b/shared/_editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# http://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.txt,wp-config-sample.php]
+end_of_line = crlf

--- a/theme/index.js
+++ b/theme/index.js
@@ -125,6 +125,7 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 		this.template( '../../shared/theme/_humans.txt', 'humans.txt' );
 		this.copy( 'theme/screenshot.png', 'screenshot.png' );
 		this.copy( '../../shared/theme/readme-includes.md', 'includes/readme.md' );
+		this.copy( '../../shared/_editorconfig', '.editorconfig' );
 	},
 
 	i18n: function() {


### PR DESCRIPTION
This copies the .editorconfig file used by WordPress itself into the templates for all 4 sub-generators automatically.

Fixes #28
