### PR TITLE
Late-escape Humans.txt URL

### DIFF
--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -91,7 +91,12 @@ function styles( $debug = false ) {
  * @return void
  */
 function header_meta() {
-	$humans = '<link type="text/plain" rel="author" href="' . <%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . '/humans.txt" />';
+	/**
+	 * Filter the path used for the site's humans.txt attribution file
+	 *
+	 * @param string $humanstxt
+	 */
+	$humanstxt = apply_filters( '<%= opts.funcPrefix %>_humans', <%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . '/humans.txt' );
 
-	echo apply_filters( '<%= opts.funcPrefix %>_humans', $humans );
+	echo '<link type="text/plain" rel="author" href="' . esc_url( $humanstxt ) . '" />';
 }


### PR DESCRIPTION
Make sure we filter the URL allowed for the humans.txt file, not the entire link element, and that we late-escape said URL for security and automated code review purposes.

Fixes #56
