### PR TITLE
removes extra closing bracket from template files

### DIFF
--- a/shared/bower/_bower.json
+++ b/shared/bower/_bower.json
@@ -2,7 +2,7 @@
   "name": "<%= opts.projectSlug %>",
   "version": "0.1.0",
   "main": "/",
-  <% if ( opts.license ) { %>}"license": "<%= opts.license %>",<% } %>
+  <% if ( opts.license ) { %>"license": "<%= opts.license %>",<% } %>
   "ignore": [
     "**/.*",
     "*.md",

--- a/shared/grunt/tasks/options/_concat.js
+++ b/shared/grunt/tasks/options/_concat.js
@@ -4,7 +4,7 @@ module.exports = {
 			banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 		' * <%%= pkg.homepage %>\n' +
 		' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-			<% if ( opts.license ) { %>}' * Licensed <%= opts.license %>' +<% } %>
+			<% if ( opts.license ) { %>' * Licensed <%= opts.license %>' +<% } %>
 		' */\n'
 	},
 	main: {

--- a/shared/grunt/tasks/options/_cssmin.js
+++ b/shared/grunt/tasks/options/_cssmin.js
@@ -3,7 +3,7 @@ module.exports = {
 		banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 		' * <%%=pkg.homepage %>\n' +
 		' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-		<% if ( opts.license ) { %>}' * Licensed <%= opts.license %>' +<% } %>
+		<% if ( opts.license ) { %>' * Licensed <%= opts.license %>' +<% } %>
 		' */\n'
 	},
 	minify: {

--- a/shared/grunt/tasks/options/_uglify.js
+++ b/shared/grunt/tasks/options/_uglify.js
@@ -7,7 +7,7 @@ module.exports = {
 			banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 			' * <%%= pkg.homepage %>\n' +
 			' * Copyright (c) <%%= grunt.template.today("yyyy") %>;' +
-			<% if ( opts.license ) { %>}' * Licensed <%= opts.license %>' +<% } %>
+			<% if ( opts.license ) { %>' * Licensed <%= opts.license %>' +<% } %>
 			' */\n',
 			mangle: {
 				except: ['jQuery']

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -3,7 +3,7 @@
  * <%= opts.projectHome %>
  *
  * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * <% if ( opts.license ) { %>}Licensed under the <%= opts.license %> license.<% } %>
+ * <% if ( opts.license ) { %>Licensed under the <%= opts.license %> license.<% } %>
  */
 
 ( function( window, undefined ) {


### PR DESCRIPTION
When the generator is run, some of the generated files contain an extra `}` before instances where the license info has been generated. This removes the extra `}` from the template files. I've tested running the generator with this change and the generated files no longer contain the extra `}`.
