### PR TITLE
Update/es6

### DIFF
--- a/child-theme/index.js
+++ b/child-theme/index.js
@@ -250,6 +250,8 @@ var ChildThemeGenerator = yeoman.generators.Base.extend( {
 		} else {
 			this.template( '../../shared/grunt/tasks/_css.js', 'tasks/css.js' );
 		}
+		this.template( '../../shared/grunt/tasks/options/_babel.js', 'tasks/options/babel.js' );
+		this.template( '../../shared/grunt/tasks/options/_browserify.js', 'tasks/options/browserify.js' );
 		this.template( '../../shared/grunt/tasks/options/_cssmin.js', 'tasks/options/cssmin.js' );
 		this.template( '../../shared/grunt/tasks/options/_clean.js', 'tasks/options/clean.js' );
 		this.template( '../../shared/grunt/tasks/options/_compress.js', 'tasks/options/compress.js' );

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-babel": "^6.0.0",
+    "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>

--- a/child-theme/templates/grunt/_package.json
+++ b/child-theme/templates/grunt/_package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
+    "babel-preset-es2015": "^6.9.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>

--- a/library/index.js
+++ b/library/index.js
@@ -156,6 +156,8 @@ var LibGenerator = yeoman.generators.Base.extend({
 			this.copy( '../../shared/conf/_jscsrc', 'conf/.jscsrc' );
 			this.copy( '../../shared/grunt/tasks/_template.js', 'tasks/_template.js');
 			this.copy( '../../shared/grunt/tasks/options/_template.js', 'tasks/options/_template.js');
+			this.template( '../../shared/grunt/tasks/options/_babel.js', 'tasks/options/babel.js' );
+			this.template( '../../shared/grunt/tasks/options/_browserify.js', 'tasks/options/browserify.js' );
 			this.template( '../../shared/grunt/tasks/options/_cssmin.js', 'tasks/options/cssmin.js' );
 			this.template( '../../shared/grunt/tasks/options/_clean.js', 'tasks/options/clean.js' );
 			this.template( '../../shared/grunt/tasks/options/_compress.js', 'tasks/options/compress.js' );

--- a/library/templates/grunt/_package.json
+++ b/library/templates/grunt/_package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
+    "babel-preset-es2015": "^6.9.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",

--- a/library/templates/grunt/_package.json
+++ b/library/templates/grunt/_package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-babel": "^6.0.0",
+    "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-cssmin": "^0.12.3",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -242,6 +242,8 @@ var PluginGenerator = yeoman.generators.Base.extend({
 		} else {
 			this.template( '../../shared/grunt/tasks/_css.js', 'tasks/css.js' );
 		}
+		this.template( '../../shared/grunt/tasks/options/_babel.js', 'tasks/options/babel.js' );
+		this.template( '../../shared/grunt/tasks/options/_browserify.js', 'tasks/options/browserify.js' );
 		this.template( '../../shared/grunt/tasks/options/_cssmin.js', 'tasks/options/cssmin.js' );
 		this.template( '../../shared/grunt/tasks/options/_clean.js', 'tasks/options/clean.js' );
 		this.template( '../../shared/grunt/tasks/options/_compress.js', 'tasks/options/compress.js' );

--- a/plugin/templates/grunt/_package.json
+++ b/plugin/templates/grunt/_package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-babel": "^6.0.0",
+    "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>

--- a/plugin/templates/grunt/_package.json
+++ b/plugin/templates/grunt/_package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
+    "babel-preset-es2015": "^6.9.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>

--- a/shared/conf/_eslintrc
+++ b/shared/conf/_eslintrc
@@ -182,7 +182,7 @@
 		"vars-on-top": [0],
 		"wrap-iife": [2, "any"],
 		"wrap-regex": [2],
-		"yoda": [2]
+		"yoda": [2, "always"]
 	},
 	"parserOptions": {
 		"ecmaVersion": 6,

--- a/shared/conf/_eslintrc
+++ b/shared/conf/_eslintrc
@@ -2,7 +2,8 @@
 	"env": {
 		"browser": true,
 		"jquery": true,
-		"node": true
+		"node": true,
+		"es6": true
 	},
 	"globals": {
 		"require": true,
@@ -182,5 +183,9 @@
 		"wrap-iife": [2, "any"],
 		"wrap-regex": [2],
 		"yoda": [2]
+	},
+	"parserOptions": {
+		"ecmaVersion": 6,
+		"sourceType": "module"
 	}
 }

--- a/shared/git/gitignore
+++ b/shared/git/gitignore
@@ -4,3 +4,5 @@ vendor
 composer.lock
 phpunit.xml
 .idea
+.*
+*~

--- a/shared/grunt/tasks/_js.js
+++ b/shared/grunt/tasks/_js.js
@@ -1,3 +1,3 @@
 module.exports = function( grunt ) {
-	grunt.registerTask( 'js', [ 'eslint', 'jscs', 'concat', 'uglify' ] );
+	grunt.registerTask( 'js', [ 'eslint', 'jscs', 'babel', 'browserify', 'uglify' ] );
 };

--- a/shared/grunt/tasks/options/_babel.js
+++ b/shared/grunt/tasks/options/_babel.js
@@ -1,0 +1,16 @@
+module.exports = {
+	all: {
+		options: {
+			sourceMap: true,
+			comments: false,
+			presets: ['es2015']
+		},
+		files : [{
+			expand : true,
+			cwd    : 'assets/js/src/',
+			src    : ['**/*.js'],
+			dest   : 'assets/js/.src-babel/',
+			ext    : '.js'
+		}]
+	}
+};

--- a/shared/grunt/tasks/options/_browserify.js
+++ b/shared/grunt/tasks/options/_browserify.js
@@ -1,0 +1,11 @@
+module.exports = {
+	all : {
+		files : [{
+			expand : true,
+			cwd    : 'assets/js/.src-babel/',
+			src    : ['*.js'],
+			dest   : 'assets/js/.src-browserify/',
+			ext    : '.js'
+		}]
+	}
+};

--- a/shared/grunt/tasks/options/_uglify.js
+++ b/shared/grunt/tasks/options/_uglify.js
@@ -1,8 +1,12 @@
 module.exports = {
 	all: {
-		files: {
-			'assets/js/<%= fileSlug %>.min.js': ['assets/js/<%= fileSlug %>.js']
-		},
+		files: [{
+			expand: true,
+			cwd: 'assets/js/.src-browserify/',
+			src: ['*.js'],
+			dest: 'assets/js/build/',
+			ext: '.min.js'
+		}],
 		options: {
 			banner: '/*! <%%= pkg.title %> - v<%%= pkg.version %>\n' +
 			' * <%%= pkg.homepage %>\n' +

--- a/shared/js/_component.js
+++ b/shared/js/_component.js
@@ -1,0 +1,2 @@
+export default function(){
+};

--- a/shared/js/_component.js
+++ b/shared/js/_component.js
@@ -1,2 +1,2 @@
-export default function(){
-};
+export default function() {
+}

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -1,7 +1,7 @@
 import component from './component/component';
 
-if( window.addEventListener ){
+if ( window.addEventListener ) {
 	window.addEventListener( 'DOMContentLoaded', component, false );
-}else if( window.attachEvent ){
+} else if ( window.attachEvent ) {
 	window.attachEvent( 'DOMContentLoaded', component );
 }

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -1,11 +1,22 @@
+/**
+ * <%= opts.projectTitle %>
+ * <%= opts.projectHome %>
+ *
+ * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
+ * <% if ( opts.license ) { %>Licensed under the <%= opts.license %> license.<% } %>
+ */
+// Import dependencies.
 import component from './component/component';
 
 if ( window.addEventListener ) {
+	// Initiate our script once the Document Object Model is set.
 	window.addEventListener( 'DOMContentLoaded', component, false );
 } else if ( window.attachEvent ) {
+	// Internet Explorer fallback. Initiate our script 'onload'.
 	window.attachEvent( 'onload', component );
 }
 
+// Initiate our script if it is loaed after the Document ready state is already complete.
 if ( 'complete' === document.readyState ) {
 	component();
 }

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -16,7 +16,7 @@ if ( window.addEventListener ) {
 	window.attachEvent( 'onload', component );
 }
 
-// Initiate our script if it is loaed after the Document ready state is already complete.
+// Initiate our script if it is loaded after the Document ready state is already complete.
 if ( 'complete' === document.readyState ) {
 	component();
 }

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -3,5 +3,9 @@ import component from './component/component';
 if ( window.addEventListener ) {
 	window.addEventListener( 'DOMContentLoaded', component, false );
 } else if ( window.attachEvent ) {
-	window.attachEvent( 'DOMContentLoaded', component );
+	window.attachEvent( 'onload', component );
+}
+
+if ( 'complete' === document.readyState ) {
+	component();
 }

--- a/shared/js/_script.js
+++ b/shared/js/_script.js
@@ -1,13 +1,7 @@
-/**
- * <%= opts.projectTitle %>
- * <%= opts.projectHome %>
- *
- * Copyright (c) <%= new Date().getFullYear() %> <%= opts.authorName %>
- * <% if ( opts.license ) { %>Licensed under the <%= opts.license %> license.<% } %>
- */
+import component from './component/component';
 
-( function( window, undefined ) {
-	'use strict';
-
-
-} )( this );
+if( window.addEventListener ){
+	window.addEventListener( 'DOMContentLoaded', component, false );
+}else if( window.attachEvent ){
+	window.attachEvent( 'DOMContentLoaded', component );
+}

--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -55,10 +55,11 @@ function scripts() {
 	 */
 	$debug = apply_filters( '<%= opts.funcPrefix %>_script_debug', false );
 	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+	$dir = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '.src-browserify' : 'build';
 
 	wp_enqueue_script(
 		'<%= opts.funcPrefix %>',
-		<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . "/assets/js/<%= fileSlug %>{$min}.js",
+		<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . "/assets/js/{$dir}/'<%= fileSlug %>{$min}.js",
 		array(),
 		<%= opts.funcPrefix.toUpperCase() %>_VERSION,
 		true

--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -61,7 +61,7 @@ function register_scripts() {
 
 	wp_register_script(
 		'<%= opts.funcPrefix %>',
-		<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . "/assets/js/{$dir}/'<%= fileSlug %>{$min}.js",
+		<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . "/assets/js/{$dir}/<%= fileSlug %>{$min}.js",
 		array(),
 		<%= opts.funcPrefix.toUpperCase() %>_VERSION,
 		true

--- a/shared/theme/_core.php
+++ b/shared/theme/_core.php
@@ -16,8 +16,10 @@ function setup() {
 	};
 
 	add_action( 'after_setup_theme',  $n( 'i18n' )        );
-	add_action( 'wp_enqueue_scripts', $n( 'scripts' )     );
-	add_action( 'wp_enqueue_scripts', $n( 'styles' )      );
+	add_action( 'init', $n( 'register_scripts' ) );
+	add_action( 'init', $n( 'register_styles' ) );
+	add_action( 'wp_enqueue_scripts', $n( 'enqueue_global_scripts' ) );
+	add_action( 'wp_enqueue_scripts', $n( 'enqueue_global_styles' ) );
 	<% if ( false !== opts.humanstxt ) { %>add_action( 'wp_head',            $n( 'header_meta' ) );<% } %>
 }
 
@@ -39,15 +41,15 @@ function i18n() {
  }
 
 /**
- * Enqueue scripts for front-end.
+ * Register scripts for front-end.
  *
- * @uses wp_enqueue_script() to load front end scripts.
+ * @uses wp_register_script() to load front end scripts.
  *
  * @since 0.1.0
  *
  * @return void
  */
-function scripts() {
+function register_scripts() {
 	/**
 	 * Flag whether to enable loading uncompressed/debugging assets. Default false.
 	 * 
@@ -57,12 +59,51 @@ function scripts() {
 	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
 	$dir = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '.src-browserify' : 'build';
 
-	wp_enqueue_script(
+	wp_register_script(
 		'<%= opts.funcPrefix %>',
 		<%= opts.funcPrefix.toUpperCase() %>_TEMPLATE_URL . "/assets/js/{$dir}/'<%= fileSlug %>{$min}.js",
 		array(),
 		<%= opts.funcPrefix.toUpperCase() %>_VERSION,
 		true
+	);
+}
+
+/**
+ * Enqueue global scripts for front-end.
+ *
+ * @uses wp_enqueue_script() to load front end scripts.
+ *
+ * @since 0.1.0
+ *
+ * @return void
+ */
+function enqueue_global_scripts() {
+	wp_enqueue_script( '<%= opts.funcPrefix %>' );
+}
+
+/**
+ * Register global styles for front-end.
+ *
+ * @uses wp_register_style() to load front end styles.
+ *
+ * @since 0.1.0
+ *
+ * @return void
+ */
+function register_styles() {
+	/**
+	 * Flag whether to enable loading uncompressed/debugging assets. Default false.
+	 *
+	 * @param bool <%= opts.funcPrefix %>_style_debug
+	 */
+	$debug = apply_filters( '<%= opts.funcPrefix %>_style_debug', false );
+	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
+
+	wp_register_style(
+		'<%= opts.funcPrefix %>',
+		<%= opts.funcPrefix.toUpperCase() %>_URL . "/assets/css/<%= fileSlug %>{$min}.css",
+		array(),
+		<%= opts.funcPrefix.toUpperCase() %>_VERSION
 	);
 }
 
@@ -75,21 +116,8 @@ function scripts() {
  *
  * @return void
  */
-function styles() {
-	/**
-	 * Flag whether to enable loading uncompressed/debugging assets. Default false.
-	 *
-	 * @param bool <%= opts.funcPrefix %>_style_debug
-	 */
-	$debug = apply_filters( '<%= opts.funcPrefix %>_style_debug', false );
-	$min = ( $debug || defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) ? '' : '.min';
-
-	wp_enqueue_style(
-		'<%= opts.funcPrefix %>',
-		<%= opts.funcPrefix.toUpperCase() %>_URL . "/assets/css/<%= fileSlug %>{$min}.css",
-		array(),
-		<%= opts.funcPrefix.toUpperCase() %>_VERSION
-	);
+function enqueue_global_styles() {
+	wp_enqueue_style( '<%= opts.funcPrefix %>' );
 }
 
 <% if ( false !== opts.humanstxt ) { %>/**

--- a/theme/index.js
+++ b/theme/index.js
@@ -250,6 +250,8 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 		} else {
 			this.template( '../../shared/grunt/tasks/_css.js', 'tasks/css.js' );
 		}
+		this.template( '../../shared/grunt/tasks/options/_babel.js', 'tasks/options/babel.js' );
+		this.template( '../../shared/grunt/tasks/options/_browserify.js', 'tasks/options/browserify.js' );
 		this.template( '../../shared/grunt/tasks/options/_cssmin.js', 'tasks/options/cssmin.js' );
 		this.template( '../../shared/grunt/tasks/options/_clean.js', 'tasks/options/clean.js' );
 		this.template( '../../shared/grunt/tasks/options/_compress.js', 'tasks/options/compress.js' );

--- a/theme/index.js
+++ b/theme/index.js
@@ -207,6 +207,7 @@ var ThemeGenerator = yeoman.generators.Base.extend({
 
 	js: function() {
 		this.template( '../../shared/js/_script.js', 'assets/js/src/' + this.fileSlug + '.js' );
+		this.template( '../../shared/js/_component.js', 'assets/js/src/component/component.js' );
 		this.copy( '../../shared/js/readme-vendor.md', 'assets/js/vendor/readme.md' );
 	},
 

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
+    "grunt-babel": "^6.0.0",
+    "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>
     "grunt-sass": "^1.0.0",<% } if ( opts.autoprefixer ) { %>

--- a/theme/templates/grunt/_package.json
+++ b/theme/templates/grunt/_package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
+    "babel-preset-es2015": "^6.9.0",
     "grunt-browserify": "^5.0.0",
     "grunt-contrib-concat": "^0.5.1",
     "grunt-contrib-uglify": "^0.9.1",<% if ( opts.sass ) { %>


### PR DESCRIPTION
This pull request includes contributions and consultation from @mrbobbybryant, @Faison, @ivankruchkoff, and @fuhton.

We think we've landed on some good defaults as a starting place. A few items that were still in open discussion:
1. Should we be including things like Babel's [polyfill](https://babeljs.io/docs/usage/polyfill/) by default? For a single page app, or a site with a single JavaScript file, but conditional polyfills via [wp_script_add_data](https://developer.wordpress.org/reference/functions/wp_script_add_data/) might be better when multiple JavaScript files could be loaded on a page.
2. In _script.js, are the < IE9 fallback and the document readystate check something that should be included by default or should we assume that IE8 support and asynchronous loading are not common enough to clutter the file with?
3. In _core.js we've updated the script actions to register on `init` and then enqueue global scripts on `wp_enqueue_scripts`. This isn't strictly necessary for the es6 update, but it makes scripts available to [wp_localize_script](https://developer.wordpress.org/reference/functions/wp_localize_script/), [wp_script_add_data](https://developer.wordpress.org/reference/functions/wp_script_add_data/), and [wp_add_inline_script](https://developer.wordpress.org/reference/functions/wp_add_inline_script/) before they are printed in the head.

@lkwdwrd We also have a draft of a description of the directory structure changes [here](https://docs.google.com/a/get10up.com/document/d/155UFTaZoM-C3ERVY98pgF4MXgi6UsODpRJqd0dpQg4c/edit?usp=sharing)
