### PR TITLE
Start making WP Make extendable

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ast-query": "^2.0.0",
     "chalk": "^1.1.1",
     "ejs": "^2.3.4",
-    "yeoman-generator": "^0.24.1",
+    "extendable-yeoman": "^0.2.1",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ast-query": "^2.0.0",
     "chalk": "^1.1.1",
     "ejs": "^2.3.4",
-    "extendable-yeoman": "^0.2.1",
+    "extendable-yeoman": "^0.3.0",
     "lodash": "^4.15.0",
     "mkdirp": "^0.5.1"
   },

--- a/src/base.js
+++ b/src/base.js
@@ -8,7 +8,7 @@
  */
 
 // Require dependencies
-var YeomanBase = require( 'yeoman-generator' ).Base;
+var Base = require( 'extendable-yeoman' ).Base;
 var _ = require( 'lodash' );
 var ejs = require( 'ejs' );
 var path = require( 'path' );
@@ -57,7 +57,7 @@ var gruntConfig = require( './util/grunt-config' );
  * methods will be run in sequence unless you specifically use the yeoman
  * queue framework to move them outside of this basic lifecycle.
  */
-var MakeBase = YeomanBase.extend( {
+var MakeBase = Base.extend( {
 	/**
 	 * This is the default whitespace used when outputting JSON and JS code.
 	 *
@@ -118,7 +118,7 @@ var MakeBase = YeomanBase.extend( {
 	 */
 	constructor: function () {
 		// Run the baser constructor.
-		YeomanBase.apply( this, arguments );
+		Base.apply( this, arguments );
 
 		// Prepare overall lifecycle.
 		this.env.runLoop.add( 'initializing', this.welcomeMessage.bind( this ), { once: 'wpm:welcome', run: false } );

--- a/src/generators/app/index.js
+++ b/src/generators/app/index.js
@@ -1,7 +1,7 @@
-var yeoman = require('yeoman-generator');
+var Base = require('extendable-yeoman').Base;
 var chalk = require('chalk');
 
-var WpMakeGenerator = yeoman.generators.Base.extend({
+module.exports = Base.extend({
 	notify: function () {
 		// replace it with a short and sweet description of your generator
 		this.log(chalk.magenta('Invoke a subgenerator to get started!'));
@@ -12,5 +12,3 @@ var WpMakeGenerator = yeoman.generators.Base.extend({
 		this.log(chalk.green('\tyo wp-make:library'));
 	}
 });
-
-module.exports = WpMakeGenerator;

--- a/src/util/prompt.js
+++ b/src/util/prompt.js
@@ -8,7 +8,7 @@
 
 // Require dependencies
 import {Base as YBase} from 'extendable-yeoman';
-const ymPrompt = Base.prototype.prompt;
+const ymPrompt = YBase.prototype.prompt;
 
 /**
  * Prompts users for input and records the results.

--- a/src/util/prompt.js
+++ b/src/util/prompt.js
@@ -7,8 +7,8 @@
  */
 
 // Require dependencies
-import Yeoman from 'yeoman-generator';
-const ymPrompt = Yeoman.Base.prototype.prompt;
+import {Base as YBase} from 'extendable-yeoman';
+const ymPrompt = Base.prototype.prompt;
 
 /**
  * Prompts users for input and records the results.


### PR DESCRIPTION
Mix in the extendable-yeoman base so that the generator can support extensions with the prefix ext-wp-make-. This will help a lot with "why don't you include X feature" type questions. With the v1 structure updates, users can create extensions to help make do whatever they need it to do for their own workflow.
