### PR TITLE
Fix composer.json indenting

### DIFF
--- a/child-theme/templates/composer/_composer.json
+++ b/child-theme/templates/composer/_composer.json
@@ -10,7 +10,7 @@
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",
 			"email": "<%= opts.authorEmail %>",
-		<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
+			<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
 			"role": "Developer"
 		}
 	],

--- a/plugin/templates/composer/_composer.json
+++ b/plugin/templates/composer/_composer.json
@@ -10,7 +10,7 @@
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",
 			"email": "<%= opts.authorEmail %>",
-		<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
+			<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
 			"role": "Developer"
 		}
 	],

--- a/theme/templates/composer/_composer.json
+++ b/theme/templates/composer/_composer.json
@@ -10,7 +10,7 @@
 		{
 			"name": "<%= ( '' !== opts.authorName ) ? opts.authorName : 'me' %>",
 			"email": "<%= opts.authorEmail %>",
-		<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
+			<% if ( opts.authorUrl ) { %>"homepage": "<%= opts.authorUrl %>",<% } %>
 			"role": "Developer"
 		}
 	],


### PR DESCRIPTION
This PR fixes in issue in which the theme, plugin, and child theme composer.json template indenting is one tab off, leading to the authors/homepage prop being indented one tab too few in each of the resulting composer.json files:

![image](https://cloud.githubusercontent.com/assets/3189678/18420651/f325f21e-784d-11e6-9dd8-2b4eaa6a3ac6.png)
