### PR TITLE
Issue #84

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "files": [
-    "app"
-  ],
   "keywords": [
     "yeoman-generator"
   ],


### PR DESCRIPTION
This resolves issue #84. When `files: {}` is declared in `package.json`, npm will only install the directories and files listed in the declaration. I've removed the `files: {}` declaration, published a test generator to npm, and have verified that all sub-generators are available.
